### PR TITLE
Added CertificateSigningRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,24 @@ Unfortunately documentation is incomplete. You may find more examples within the
 
 `CertificateBuilder` requires the [FluentCertificates.Builder](https://www.nuget.org/packages/FluentCertificates.Builder) package and is found under the `FluentCertificates` namespace.
 
+### **The absolute minimum needed to create a certificate (although it may not be a very useful one):**
+
+```csharp
+using var cert = new CertificateBuilder().Build();
+```
+
 ### **Create a `CertificateRequest` for signing, exporting and passing to a 3rd party CA:**
 
 ```csharp
+//A public & private keypair must be created first, outside of the CertificateBuilder, otherwise you'd have no way to retrieve the private-key used for the new CertificateRequest object
+using var keys = RSA.Create();
+
+//Creating a CertificateRequest
 var request = new CertificateBuilder()
     .SetUsage(CertificateUsage.Server)
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
+    .SetKeyPair(keys)
     .ToCertificateRequest();
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,19 +27,28 @@ Unfortunately documentation is incomplete. You may find more examples within the
 using var cert = new CertificateBuilder().Create();
 ```
 
-### **Create a `CertificateRequest` for signing, exporting and passing to a 3rd party CA:**
+### **Create a `CertificateSigningRequest` for signing, exporting and passing to a 3rd party CA:**
 
 ```csharp
-//A public & private keypair must be created first, outside of the CertificateBuilder, otherwise you'd have no way to retrieve the private-key used for the new CertificateRequest object
+//A public & private keypair must be created first, outside of the CertificateBuilder, otherwise you'd have no way to retrieve the private-key used for the new CertificateSigningRequest object
 using var keys = RSA.Create();
 
-//Creating a CertificateRequest
-var request = new CertificateBuilder()
+//Creating a CertificateSigningRequest
+var csr = new CertificateBuilder()
     .SetUsage(CertificateUsage.Server)
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
     .SetKeyPair(keys)
-    .CreateCertificateRequest();
+    .CreateCertificateSigningRequest();
+
+//The CertificateRequest object is accessible here:
+var certRequest = csr.CertificateRequest;
+
+//CSR can be exported to a string
+Console.WriteLine(csr.ToPemString());
+
+//Or to a file or StringWriter instance
+csr.ExportAsPem("csr.pem");
 ```
 
 ### **Build a self-signed web server certificate:**
@@ -138,7 +147,7 @@ These extension methods require the [FluentCertificates.Builder](https://www.nug
 |`ToBase64String`||
 |`GetPrivateKey`||
 |`GetSignatureData`||
-|`GetTbsData`||
+|`GetToBeSignedData`||
 |`IsValidNow`||
 |`IsValid`||
 |`IsSelfSigned`||

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Unfortunately documentation is incomplete. You may find more examples within the
 ### **The absolute minimum needed to create a certificate (although it may not be a very useful one):**
 
 ```csharp
-using var cert = new CertificateBuilder().Build();
+using var cert = new CertificateBuilder().Create();
 ```
 
 ### **Create a `CertificateRequest` for signing, exporting and passing to a 3rd party CA:**
@@ -39,7 +39,7 @@ var request = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
     .SetKeyPair(keys)
-    .ToCertificateRequest();
+    .CreateCertificateRequest();
 ```
 
 ### **Build a self-signed web server certificate:**
@@ -52,7 +52,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
     .SetNotAfter(DateTimeOffset.UtcNow.AddMonths(1))
-    .Build();
+    .Create();
 
 //And just to demonstrate using object initializers (I'll use fluent style from now on though)
 using var builder = new CertificateBuilder() {
@@ -62,7 +62,7 @@ using var builder = new CertificateBuilder() {
     DnsNames = new[] { "*.fake.domain", "fake.domain" },
     NotAfter = DateTimeOffset.UtcNow.AddMonths(1)
 };
-var cert = builder.Build();
+var cert = builder.Create();
 ```
 
 ### **Build a CA (certificate authority):**
@@ -74,7 +74,7 @@ using var issuer = new CertificateBuilder()
     .SetFriendlyName("Example root CA")
     .SetSubject(b => b.SetCommonName("Example root CA"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(100))
-    .Build();
+    .Create();
 ```
 
 ### **Build a client-auth certificate signed by a CA:**
@@ -87,7 +87,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("User: Michael"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(1))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ### **Advanced: Build a certificate with customized extensions:**
@@ -100,7 +100,7 @@ using var cert = new CertificateBuilder()
     .AddExtension(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment, true))
     .AddExtension(new X509EnhancedKeyUsageExtension(new OidCollection { new(KeyPurposeID.AnyExtendedKeyUsage.Id) }, false))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ---

--- a/src/FluentCertificates.Builder/CertificateBuilder.cs
+++ b/src/FluentCertificates.Builder/CertificateBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System.Buffers.Binary;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -115,7 +114,7 @@ public partial record CertificateBuilder
     /// <remarks>
     /// Keys provided through this method are NOT automatically disposed by the CertificateBuilder so it is the caller's responsibility to manage that.
     /// </remarks>
-    /// <param name="value">A public-private keypair. Supported algorithms currently include RSA, ECDsa and the deprecated DSA. Set as null to immediately remove a previously supplied key from the builder.</param>
+    /// <param name="value">A public-private keypair. Supported algorithms currently include RSA, ECDsa and the deprecated DSA. Set as <see langword="null" /> to immediately remove a previously supplied key from the builder.</param>
     /// <returns>A new instance of CertificateBuilder with the specified key-pair set.</returns>
     public CertificateBuilder SetKeyPair(AsymmetricAlgorithm? value)
         => this with {
@@ -213,12 +212,12 @@ public partial record CertificateBuilder
     }
 
 
-    public byte[] BuildCertificateSigningRequest()
-    {
-        var request = BuildCertificateRequest();
-        var sigGenerator = CreateSignatureGenerator(KeyPair);
-        return request.CreateSigningRequest(sigGenerator);
-    }
+    /// <summary>
+    /// Builds a CertificateSigningRequest object bsaed on the parameters that have been set previously in the builder.
+    /// </summary>
+    /// <returns></returns>
+    public CertificateSigningRequest BuildCertificateSigningRequest()
+        => new(BuildCertificateRequest(), CreateSignatureGenerator(KeyPair));
 
 
     /// <summary>

--- a/src/FluentCertificates.Builder/CertificateBuilder.cs
+++ b/src/FluentCertificates.Builder/CertificateBuilder.cs
@@ -194,7 +194,7 @@ public partial record CertificateBuilder
     public CertificateRequest ToCertificateRequest()
     {
         if (PublicKey == null) {
-            throw new ArgumentNullException($"Call {nameof(SetKeyPair)}(...) or {nameof(SetKeyAlgorithm)}() first to provide a public/private keypair");
+            throw new ArgumentNullException($"Call {nameof(SetKeyPair)}(...) first to provide a public/private keypair");
         }
 
         var dn = Subject.Build();

--- a/src/FluentCertificates.Builder/CertificateBuilder.cs
+++ b/src/FluentCertificates.Builder/CertificateBuilder.cs
@@ -125,7 +125,7 @@ public partial record CertificateBuilder
 
     /// <summary>
     /// Use this to specify the algorithm to use when automatically generating new keys for a certificate. If a KeyPair was
-    /// previously been manually supplied, this will remove it from the builder. Each time the Build() method is called, a
+    /// previously been manually supplied, this will remove it from the builder. Each time the Create() method is called, a
     /// new key-pair will be generated and immediately disposed upon return.
     /// </summary>
     /// <param name="value">The type of algorithm to use for generating the keys. Supported algorithms currently include RSA, ECDsa and the deprecated DSA. The default is RSA.</param>
@@ -186,17 +186,17 @@ public partial record CertificateBuilder
 
 
     /// <summary>
-    /// Build a CertificateRequest based on the parameters that have been set previously in the builder.
+    /// Create a CertificateRequest based on the parameters that have been set previously in the builder.
     /// </summary>
     /// <returns>A CertificateRequest instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when the SetKeyPair(AsymmetricAlgorithm) method has not been called.</exception>
-    public CertificateRequest BuildCertificateRequest()
+    public CertificateRequest CreateCertificateRequest()
     {
         if (PublicKey == null) {
             throw new ArgumentNullException($"Call {nameof(SetKeyPair)}(...) first to provide a public/private keypair");
         }
 
-        var dn = Subject.Build();
+        var dn = Subject.Create();
 
         var request = new CertificateRequest(dn, PublicKey, HashAlgorithm);
 
@@ -216,8 +216,8 @@ public partial record CertificateBuilder
     /// Builds a CertificateSigningRequest object bsaed on the parameters that have been set previously in the builder.
     /// </summary>
     /// <returns></returns>
-    public CertificateSigningRequest BuildCertificateSigningRequest()
-        => new(BuildCertificateRequest(), CreateSignatureGenerator(KeyPair));
+    public CertificateSigningRequest CreateCertificateSigningRequest()
+        => new(CreateCertificateRequest(), CreateSignatureGenerator(KeyPair));
 
 
     /// <summary>
@@ -225,7 +225,7 @@ public partial record CertificateBuilder
     /// </summary>
     /// <returns>An X509Certificate2 instance.</returns>
     [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Call site is only reachable on supported platforms")]
-    public X509Certificate2 Build()
+    public X509Certificate2 Create()
     {
         Validate();
 
@@ -240,7 +240,7 @@ public partial record CertificateBuilder
                 throw new ArgumentNullException($"Call {nameof(SetKeyPair)}(...) or {nameof(SetKeyAlgorithm)}() first to provide a public/private keypair");
             }
 
-            var request = builder.BuildCertificateRequest();
+            var request = builder.CreateCertificateRequest();
 
             var cert = builder.Issuer != null
                 ? request.Create(
@@ -251,7 +251,7 @@ public partial record CertificateBuilder
                     builder.GenerateSerialNumber()
                 )
                 : request.Create(
-                    builder.Subject.Build(),
+                    builder.Subject.Create(),
                     builder.CreateSignatureGenerator(builder.KeyPair),
                     builder.NotBefore,
                     builder.NotAfter,

--- a/src/FluentCertificates.Builder/CertificateSigningRequest.cs
+++ b/src/FluentCertificates.Builder/CertificateSigningRequest.cs
@@ -1,0 +1,63 @@
+﻿using System.Formats.Asn1;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+
+namespace FluentCertificates;
+
+public record CertificateSigningRequest
+{
+    public CertificateRequest CertificateRequest { get; init; }
+    public X509SignatureGenerator SignatureGenerator { get; init; }
+    public byte[] RawData { get; init; }
+
+
+    internal CertificateSigningRequest(CertificateRequest certificateRequest, X509SignatureGenerator signatureGenerator)
+    {
+        CertificateRequest = certificateRequest;
+        SignatureGenerator = signatureGenerator;
+        RawData = CertificateRequest.CreateSigningRequest(SignatureGenerator);
+    }
+
+
+    /// <summary>Creates an ASN.1 DER-encoded PKCS#10 CertificationRequest value representing the state of the current <see cref="P:CertificateRequest"/> property signed using the current <see cref="P:SignatureGenerator"/>.</summary>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">The <see cref="P:System.Security.Cryptography.X509Certificates.CertificateRequest.HashAlgorithm" /> property value is not supported.</exception>
+    /// <returns>A DER-encoded certificate signing request as a raw byte array.</returns>
+    public byte[] GetRawData()
+        => RawData;
+
+
+    public byte[] GetRequestData()
+        => throw new NotImplementedException();
+
+
+    public byte[] GetSignatureData()
+        => throw new NotImplementedException();
+
+
+    public static SignatureAlgorithm GetSignatureAlgorithm()
+        => throw new NotImplementedException();
+
+
+    public CertificateSigningRequest ExportAsPem(TextWriter writer)
+    {
+        writer.Write(ToPemString());
+        return this;
+    }
+
+    
+    public CertificateSigningRequest ExportAsPem(string path)
+    {
+        using var stream = File.OpenWrite(path);
+        using var writer = new StreamWriter(stream);
+        return ExportAsPem(writer);
+    }
+
+
+    public string ToPemString()
+    {
+        using var sw = new StringWriter();
+        sw.Write(PemEncoding.Write("CERTIFICATE REQUEST", GetRawData()));
+        return sw.ToString();
+    }
+}

--- a/src/FluentCertificates.Builder/CertificateSigningRequest.cs
+++ b/src/FluentCertificates.Builder/CertificateSigningRequest.cs
@@ -23,20 +23,41 @@ public record CertificateSigningRequest
     /// <summary>Creates an ASN.1 DER-encoded PKCS#10 CertificationRequest value representing the state of the current <see cref="P:CertificateRequest"/> property signed using the current <see cref="P:SignatureGenerator"/>.</summary>
     /// <exception cref="T:System.ArgumentOutOfRangeException">The <see cref="P:System.Security.Cryptography.X509Certificates.CertificateRequest.HashAlgorithm" /> property value is not supported.</exception>
     /// <returns>A DER-encoded certificate signing request as a raw byte array.</returns>
-    public byte[] GetRawData()
+    public ReadOnlyMemory<byte> GetRawData()
         => RawData;
 
-
-    public byte[] GetRequestData()
-        => throw new NotImplementedException();
-
-
-    public byte[] GetSignatureData()
-        => throw new NotImplementedException();
+    
+    public ReadOnlyMemory<byte> GetRequestData()
+        => new AsnReader(RawData, AsnEncodingRules.DER)
+            .ReadSequence(Asn1Tag.Sequence)
+            .ReadEncodedValue();
 
 
-    public static SignatureAlgorithm GetSignatureAlgorithm()
-        => throw new NotImplementedException();
+    public ReadOnlyMemory<byte> GetSignatureData()
+    {
+        var reader = new AsnReader(RawData, AsnEncodingRules.DER).ReadSequence(Asn1Tag.Sequence);
+        reader.ReadSequence(Asn1Tag.Sequence); //Skip CertificationRequestInfo
+        reader.ReadSequence(Asn1Tag.Sequence); //Skip Signature AlgorithmIdentifier
+        return reader.ReadBitString(out _, Asn1Tag.PrimitiveBitString);
+    }
+
+
+    public SignatureAlgorithm GetSignatureAlgorithm()
+    {
+        var reader = new AsnReader(RawData, AsnEncodingRules.DER).ReadSequence(Asn1Tag.Sequence);
+        reader.ReadSequence(Asn1Tag.Sequence); //Skip CertificationRequestInfo
+        var algIdentifier = reader.ReadSequence(Asn1Tag.Sequence);
+        var algorithm = algIdentifier.ReadObjectIdentifier(Asn1Tag.ObjectIdentifier);
+        if (algorithm == "1.2.840.113549.1.1.10") {
+            var hashAlgorithm = algIdentifier
+                .ReadSequence(Asn1Tag.Sequence)
+                .ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0))
+                .ReadSequence(Asn1Tag.Sequence)
+                .ReadObjectIdentifier(Asn1Tag.ObjectIdentifier);
+            return SignatureAlgorithm.ForRsaSsaPss(algorithm, hashAlgorithm);
+        }
+        return SignatureAlgorithm.FromOidValue(algorithm);
+    }
 
 
     public CertificateSigningRequest ExportAsPem(TextWriter writer)
@@ -57,7 +78,7 @@ public record CertificateSigningRequest
     public string ToPemString()
     {
         using var sw = new StringWriter();
-        sw.Write(PemEncoding.Write("CERTIFICATE REQUEST", GetRawData()));
+        sw.Write(PemEncoding.Write("CERTIFICATE REQUEST", GetRawData().Span));
         return sw.ToString();
     }
 }

--- a/src/FluentCertificates.Builder/README.md
+++ b/src/FluentCertificates.Builder/README.md
@@ -21,14 +21,25 @@ Unfortunately documentation is incomplete. You may find more examples within the
 
 `CertificateBuilder` requires the [FluentCertificates.Builder](https://www.nuget.org/packages/FluentCertificates.Builder) package and is found under the `FluentCertificates` namespace.
 
+### **The absolute minimum needed to create a certificate (although it may not be a very useful one):**
+
+```csharp
+using var cert = new CertificateBuilder().Create();
+```
+
 ### **Create a `CertificateRequest` for signing, exporting and passing to a 3rd party CA:**
 
 ```csharp
+//A public & private keypair must be created first, outside of the CertificateBuilder, otherwise you'd have no way to retrieve the private-key used for the new CertificateRequest object
+using var keys = RSA.Create();
+
+//Creating a CertificateRequest
 var request = new CertificateBuilder()
     .SetUsage(CertificateUsage.Server)
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
-    .ToCertificateRequest();
+    .SetKeyPair(keys)
+    .CreateCertificateRequest();
 ```
 
 ### **Build a self-signed web server certificate:**
@@ -41,7 +52,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
     .SetNotAfter(DateTimeOffset.UtcNow.AddMonths(1))
-    .Build();
+    .Create();
 
 //And just to demonstrate using object initializers (I'll use fluent style from now on though)
 using var builder = new CertificateBuilder() {
@@ -51,7 +62,7 @@ using var builder = new CertificateBuilder() {
     DnsNames = new[] { "*.fake.domain", "fake.domain" },
     NotAfter = DateTimeOffset.UtcNow.AddMonths(1)
 };
-var cert = builder.Build();
+var cert = builder.Create();
 ```
 
 ### **Build a CA (certificate authority):**
@@ -63,7 +74,7 @@ using var issuer = new CertificateBuilder()
     .SetFriendlyName("Example root CA")
     .SetSubject(b => b.SetCommonName("Example root CA"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(100))
-    .Build();
+    .Create();
 ```
 
 ### **Build a client-auth certificate signed by a CA:**
@@ -76,7 +87,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("User: Michael"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(1))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ### **Advanced: Build a certificate with customized extensions:**
@@ -89,7 +100,7 @@ using var cert = new CertificateBuilder()
     .AddExtension(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment, true))
     .AddExtension(new X509EnhancedKeyUsageExtension(new OidCollection { new(KeyPurposeID.AnyExtendedKeyUsage.Id) }, false))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ---

--- a/src/FluentCertificates.Builder/X500NameBuilder.cs
+++ b/src/FluentCertificates.Builder/X500NameBuilder.cs
@@ -37,7 +37,7 @@ public record X500NameBuilder
     public ImmutableList<(Oid OID, string Value)> Attributes { get; init; } = ImmutableList<(Oid, string)>.Empty;
 
 
-    public X500DistinguishedName Build()
+    public X500DistinguishedName Create()
         => new(ToX509Name().ToString());
 
     

--- a/src/FluentCertificates.Extensions/FluentCertificates.Extensions.csproj
+++ b/src/FluentCertificates.Extensions/FluentCertificates.Extensions.csproj
@@ -19,6 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="LINQPadQuery" />
+    <InternalsVisibleTo Include="FluentCertificates.Builder" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
   </ItemGroup>
 

--- a/src/FluentCertificates.Extensions/README.md
+++ b/src/FluentCertificates.Extensions/README.md
@@ -21,14 +21,25 @@ Unfortunately documentation is incomplete. You may find more examples within the
 
 `CertificateBuilder` requires the [FluentCertificates.Builder](https://www.nuget.org/packages/FluentCertificates.Builder) package and is found under the `FluentCertificates` namespace.
 
+### **The absolute minimum needed to create a certificate (although it may not be a very useful one):**
+
+```csharp
+using var cert = new CertificateBuilder().Create();
+```
+
 ### **Create a `CertificateRequest` for signing, exporting and passing to a 3rd party CA:**
 
 ```csharp
+//A public & private keypair must be created first, outside of the CertificateBuilder, otherwise you'd have no way to retrieve the private-key used for the new CertificateRequest object
+using var keys = RSA.Create();
+
+//Creating a CertificateRequest
 var request = new CertificateBuilder()
     .SetUsage(CertificateUsage.Server)
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
-    .ToCertificateRequest();
+    .SetKeyPair(keys)
+    .CreateCertificateRequest();
 ```
 
 ### **Build a self-signed web server certificate:**
@@ -41,7 +52,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
     .SetNotAfter(DateTimeOffset.UtcNow.AddMonths(1))
-    .Build();
+    .Create();
 
 //And just to demonstrate using object initializers (I'll use fluent style from now on though)
 using var builder = new CertificateBuilder() {
@@ -51,7 +62,7 @@ using var builder = new CertificateBuilder() {
     DnsNames = new[] { "*.fake.domain", "fake.domain" },
     NotAfter = DateTimeOffset.UtcNow.AddMonths(1)
 };
-var cert = builder.Build();
+var cert = builder.Create();
 ```
 
 ### **Build a CA (certificate authority):**
@@ -63,7 +74,7 @@ using var issuer = new CertificateBuilder()
     .SetFriendlyName("Example root CA")
     .SetSubject(b => b.SetCommonName("Example root CA"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(100))
-    .Build();
+    .Create();
 ```
 
 ### **Build a client-auth certificate signed by a CA:**
@@ -76,7 +87,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("User: Michael"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(1))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ### **Advanced: Build a certificate with customized extensions:**
@@ -89,7 +100,7 @@ using var cert = new CertificateBuilder()
     .AddExtension(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment, true))
     .AddExtension(new X509EnhancedKeyUsageExtension(new OidCollection { new(KeyPurposeID.AnyExtendedKeyUsage.Id) }, false))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ---

--- a/src/FluentCertificates.Finder/README.md
+++ b/src/FluentCertificates.Finder/README.md
@@ -21,14 +21,25 @@ Unfortunately documentation is incomplete. You may find more examples within the
 
 `CertificateBuilder` requires the [FluentCertificates.Builder](https://www.nuget.org/packages/FluentCertificates.Builder) package and is found under the `FluentCertificates` namespace.
 
+### **The absolute minimum needed to create a certificate (although it may not be a very useful one):**
+
+```csharp
+using var cert = new CertificateBuilder().Create();
+```
+
 ### **Create a `CertificateRequest` for signing, exporting and passing to a 3rd party CA:**
 
 ```csharp
+//A public & private keypair must be created first, outside of the CertificateBuilder, otherwise you'd have no way to retrieve the private-key used for the new CertificateRequest object
+using var keys = RSA.Create();
+
+//Creating a CertificateRequest
 var request = new CertificateBuilder()
     .SetUsage(CertificateUsage.Server)
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
-    .ToCertificateRequest();
+    .SetKeyPair(keys)
+    .CreateCertificateRequest();
 ```
 
 ### **Build a self-signed web server certificate:**
@@ -41,7 +52,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
     .SetNotAfter(DateTimeOffset.UtcNow.AddMonths(1))
-    .Build();
+    .Create();
 
 //And just to demonstrate using object initializers (I'll use fluent style from now on though)
 using var builder = new CertificateBuilder() {
@@ -51,7 +62,7 @@ using var builder = new CertificateBuilder() {
     DnsNames = new[] { "*.fake.domain", "fake.domain" },
     NotAfter = DateTimeOffset.UtcNow.AddMonths(1)
 };
-var cert = builder.Build();
+var cert = builder.Create();
 ```
 
 ### **Build a CA (certificate authority):**
@@ -63,7 +74,7 @@ using var issuer = new CertificateBuilder()
     .SetFriendlyName("Example root CA")
     .SetSubject(b => b.SetCommonName("Example root CA"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(100))
-    .Build();
+    .Create();
 ```
 
 ### **Build a client-auth certificate signed by a CA:**
@@ -76,7 +87,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("User: Michael"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(1))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ### **Advanced: Build a certificate with customized extensions:**
@@ -89,7 +100,7 @@ using var cert = new CertificateBuilder()
     .AddExtension(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment, true))
     .AddExtension(new X509EnhancedKeyUsageExtension(new OidCollection { new(KeyPurposeID.AnyExtendedKeyUsage.Id) }, false))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ---

--- a/src/FluentCertificates.Polyfills/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.cs
+++ b/src/FluentCertificates.Polyfills/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography.Asn1
     [StructLayout(LayoutKind.Sequential)]
     internal partial struct SubjectPublicKeyInfoAsn
     {
-        internal System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn Algorithm;
+        internal AlgorithmIdentifierAsn Algorithm;
         internal ReadOnlyMemory<byte> SubjectPublicKey;
 
         internal void Encode(AsnWriter writer)
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Asn1
             int offset;
             ReadOnlySpan<byte> tmpSpan;
 
-            System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref sequenceReader, rebind, out decoded.Algorithm);
+            AlgorithmIdentifierAsn.Decode(ref sequenceReader, rebind, out decoded.Algorithm);
 
             if (sequenceReader.TryReadPrimitiveBitString(out _, out tmpSpan)) {
                 decoded.SubjectPublicKey = rebindSpan.Overlaps(tmpSpan, out offset) ? rebind.Slice(offset, tmpSpan.Length) : tmpSpan.ToArray();

--- a/src/FluentCertificates.Polyfills/System/Security/Cryptography/DSAExtensions.cs
+++ b/src/FluentCertificates.Polyfills/System/Security/Cryptography/DSAExtensions.cs
@@ -1,0 +1,35 @@
+﻿#if NETSTANDARD
+// ReSharper disable All
+
+namespace System.Security.Cryptography;
+
+public static class DSAExtensions
+{
+    public static bool VerifyData(this DSA key, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm, DSASignatureFormat signatureFormat)
+    {
+        var sig = key.ConvertSignatureToIeeeP1363(DSASignatureFormat.Rfc3279DerSequence, signature);
+
+        //If the signature failed normalization to P1363, it obviously doesn't verify.
+        if (sig == null) {
+            return false;
+        }
+
+        return key.VerifyData(data, sig, hashAlgorithm);
+    }
+
+
+    public static bool VerifyData(this DSA key, ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, DSASignatureFormat signatureFormat)
+    {
+        var sig = key.ConvertSignatureToIeeeP1363(DSASignatureFormat.Rfc3279DerSequence, signature);
+
+        //If the signature failed normalization to P1363, it obviously doesn't verify.
+        if (sig == null) {
+            return false;
+        }
+
+        return key.VerifyData(data, sig, hashAlgorithm);
+    }
+
+}
+
+#endif

--- a/src/FluentCertificates.Polyfills/System/Security/Cryptography/X509Certificates/PublicKeyExtensions.cs
+++ b/src/FluentCertificates.Polyfills/System/Security/Cryptography/X509Certificates/PublicKeyExtensions.cs
@@ -1,0 +1,124 @@
+﻿#if !NET6_0_OR_GREATER
+
+// ReSharper disable All
+
+using System.Formats.Asn1;
+using System.Runtime.Versioning;
+using System.Security.Cryptography.Asn1;
+
+namespace System.Security.Cryptography.X509Certificates;
+
+public static class PublicKeyExtensions
+{
+    
+    /// <summary>Gets the <see cref="T:System.Security.Cryptography.RSA" /> public key, or <see langword="null" /> if the key is not an RSA key.</summary>
+    /// <exception cref="T:System.Security.Cryptography.CryptographicException">The key contents are corrupt or could not be read successfully.</exception>
+    /// <returns>The public key, or <see langword="null" /> if the key is not an RSA key.</returns>
+    public static RSA? GetRSAPublicKey(this PublicKey pk)
+    {
+        if (pk.Oid.Value != "1.2.840.113549.1.1.1") {
+            return null;
+        }
+
+        var rsa = RSA.Create();
+        try {
+            rsa.ImportSubjectPublicKeyInfo(pk.ExportSubjectPublicKeyInfo(), out _);
+            return rsa;
+        } catch {
+            rsa.Dispose();
+            throw;
+        }
+    }
+    
+
+    /// <summary>Gets the <see cref="T:System.Security.Cryptography.DSA" /> public key, or <see langword="null" /> if the key is not an DSA key.</summary>
+    /// <exception cref="T:System.Security.Cryptography.CryptographicException">The key contents are corrupt or could not be read successfully.</exception>
+    /// <returns>The public key, or <see langword="null" /> if the key is not an DSA key.</returns>
+    #if NET5_0_OR_GREATER
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    #endif
+    public static DSA? GetDSAPublicKey(this PublicKey pk)
+    {
+        if (pk.Oid.Value != "1.2.840.10040.4.1") {
+            return null;
+        }
+
+        var dsa = DSA.Create();
+        try {
+            dsa.ImportSubjectPublicKeyInfo(pk.ExportSubjectPublicKeyInfo(), out _);
+            return dsa;
+        } catch {
+            dsa.Dispose();
+            throw;
+        }
+    }
+
+
+    /// <summary>Gets the <see cref="T:System.Security.Cryptography.ECDsa" /> public key, or <see langword="null" /> if the key is not an ECDsa key.</summary>
+    /// <exception cref="T:System.Security.Cryptography.CryptographicException">The key contents are corrupt or could not be read successfully.</exception>
+    /// <returns>The public key, or <see langword="null" /> if the key is not an ECDsa key.</returns>
+    public static ECDsa? GetECDsaPublicKey(this PublicKey pk)
+    {
+        if (pk.Oid.Value != "1.2.840.10045.2.1") {
+            return null;
+        }
+
+        var ecdsa = ECDsa.Create();
+        try {
+            ecdsa.ImportSubjectPublicKeyInfo(pk.ExportSubjectPublicKeyInfo(), out _);
+            return ecdsa;
+        } catch {
+            ecdsa.Dispose();
+            throw;
+        }
+    }
+
+
+    /// <summary>Gets the <see cref="T:System.Security.Cryptography.ECDiffieHellman" /> public key, or <see langword="null" /> if the key is not an ECDiffieHellman key.</summary>
+    /// <exception cref="T:System.Security.Cryptography.CryptographicException">The key contents are corrupt or could not be read successfully.</exception>
+    /// <returns>The public key, or <see langword="null" /> if the key is not an ECDiffieHellman key.</returns>
+    public static ECDiffieHellman? GetECDiffieHellmanPublicKey(this PublicKey pk)
+    {
+        if (pk.Oid.Value != "1.2.840.10045.2.1") {
+            return null;
+        }
+
+        var ecdh = ECDiffieHellman.Create();
+        try {
+            ecdh.ImportSubjectPublicKeyInfo(pk.ExportSubjectPublicKeyInfo(), out _);
+            return ecdh;
+        } catch {
+            ecdh.Dispose();
+            throw;
+        }
+    }
+
+
+    /// <summary>
+    /// Exports the current key in the X.509 SubjectPublicKeyInfo format.
+    /// </summary>
+    /// <returns>
+    /// A byte array containing the X.509 SubjectPublicKeyInfo representation of this key.
+    /// </returns>
+    public static byte[] ExportSubjectPublicKeyInfo(this PublicKey pk)
+        => EncodeSubjectPublicKeyInfo(pk).Encode();
+    
+
+    private static AsnWriter EncodeSubjectPublicKeyInfo(PublicKey pk)
+    {
+        SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn {
+            Algorithm = new AlgorithmIdentifierAsn {
+                Algorithm = pk.Oid.Value ?? string.Empty,
+                Parameters =  pk.EncodedParameters.RawData,
+            },
+            SubjectPublicKey = pk.EncodedKeyValue.RawData,
+        };
+
+        AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+        spki.Encode(writer);
+        return writer;
+    }
+}
+
+#endif

--- a/src/FluentCertificates/README.md
+++ b/src/FluentCertificates/README.md
@@ -21,14 +21,25 @@ Unfortunately documentation is incomplete. You may find more examples within the
 
 `CertificateBuilder` requires the [FluentCertificates.Builder](https://www.nuget.org/packages/FluentCertificates.Builder) package and is found under the `FluentCertificates` namespace.
 
+### **The absolute minimum needed to create a certificate (although it may not be a very useful one):**
+
+```csharp
+using var cert = new CertificateBuilder().Create();
+```
+
 ### **Create a `CertificateRequest` for signing, exporting and passing to a 3rd party CA:**
 
 ```csharp
+//A public & private keypair must be created first, outside of the CertificateBuilder, otherwise you'd have no way to retrieve the private-key used for the new CertificateRequest object
+using var keys = RSA.Create();
+
+//Creating a CertificateRequest
 var request = new CertificateBuilder()
     .SetUsage(CertificateUsage.Server)
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
-    .ToCertificateRequest();
+    .SetKeyPair(keys)
+    .CreateCertificateRequest();
 ```
 
 ### **Build a self-signed web server certificate:**
@@ -41,7 +52,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("*.fake.domain"))
     .SetDnsNames("*.fake.domain", "fake.domain")
     .SetNotAfter(DateTimeOffset.UtcNow.AddMonths(1))
-    .Build();
+    .Create();
 
 //And just to demonstrate using object initializers (I'll use fluent style from now on though)
 using var builder = new CertificateBuilder() {
@@ -51,7 +62,7 @@ using var builder = new CertificateBuilder() {
     DnsNames = new[] { "*.fake.domain", "fake.domain" },
     NotAfter = DateTimeOffset.UtcNow.AddMonths(1)
 };
-var cert = builder.Build();
+var cert = builder.Create();
 ```
 
 ### **Build a CA (certificate authority):**
@@ -63,7 +74,7 @@ using var issuer = new CertificateBuilder()
     .SetFriendlyName("Example root CA")
     .SetSubject(b => b.SetCommonName("Example root CA"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(100))
-    .Build();
+    .Create();
 ```
 
 ### **Build a client-auth certificate signed by a CA:**
@@ -76,7 +87,7 @@ using var cert = new CertificateBuilder()
     .SetSubject(b => b.SetCommonName("User: Michael"))
     .SetNotAfter(DateTimeOffset.UtcNow.AddYears(1))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ### **Advanced: Build a certificate with customized extensions:**
@@ -89,7 +100,7 @@ using var cert = new CertificateBuilder()
     .AddExtension(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment, true))
     .AddExtension(new X509EnhancedKeyUsageExtension(new OidCollection { new(KeyPurposeID.AnyExtendedKeyUsage.Id) }, false))
     .SetIssuer(issuer)
-    .Build();
+    .Create();
 ```
 
 ---

--- a/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
+++ b/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
@@ -28,7 +28,7 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_NewCertificate_HasPrivateKey()
+    public void Build_Certificate_HasPrivateKey()
     {
         using var cert = new CertificateBuilder().Build();
         Assert.True(cert.HasPrivateKey);
@@ -36,9 +36,9 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_NewCertificate_WithSubject()
+    public void Build_Certificate_WithSubject()
     {
-        const string testName = nameof(Build_NewCertificate_WithSubject);
+        const string testName = nameof(Build_Certificate_WithSubject);
         const string expected = $"CN={testName}";
 
         //Test several different, equivalent ways of setting the Subject
@@ -64,7 +64,7 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_NewCertificate_WithRSAKeys()
+    public void Build_Certificate_WithRSAKeys()
     {
         using var keys = RSA.Create();
         using var cert1 = new CertificateBuilder().SetKeyPair(keys).Build();
@@ -76,7 +76,7 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_NewCertificate_WithECDsaKeys()
+    public void Build_Certificate_WithECDsaKeys()
     {
         using var keys = ECDsa.Create();
         using var cert1 = new CertificateBuilder().SetKeyPair(keys).Build();
@@ -88,7 +88,7 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_NewCertificate_WithDSAKeys()
+    public void Build_Certificate_WithDSAKeys()
     {
         using var keys = DSA.Create(1024);
         using var cert1 = new CertificateBuilder().SetKeyPair(keys).Build();
@@ -100,7 +100,7 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_NewRSACertificate_WithECDsaIssuer()
+    public void Build_RSACertificate_WithECDsaIssuer()
     {
         var now = DateTimeOffset.UtcNow;
 
@@ -121,7 +121,7 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_NewECDsaCertificate_WithRSAIssuer()
+    public void Build_ECDsaCertificate_WithRSAIssuer()
     {
         var now = DateTimeOffset.UtcNow;
 
@@ -253,7 +253,7 @@ public class CertificateBuilderTests
 
 
     [Fact]
-    public void Build_CertificateSigningRequest_WithExternalKeys()
+    public void Build_CertificateSigningRequest_WithRSAKeys()
     {
         using var keys = RSA.Create();
 

--- a/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
+++ b/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
@@ -261,7 +261,9 @@ public class CertificateBuilderTests
             .SetKeyPair(keys)
             .BuildCertificateSigningRequest();
 
-        Assert.NotEmpty(csr);
+        Assert.NotEmpty(csr.GetRawData());
+        
+        //TODO: verify signatures
     }
 
 

--- a/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
+++ b/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
@@ -30,7 +30,7 @@ public class CertificateBuilderTests
     [Fact]
     public void Build_Certificate_HasPrivateKey()
     {
-        using var cert = new CertificateBuilder().Build();
+        using var cert = new CertificateBuilder().Create();
         Assert.True(cert.HasPrivateKey);
     }
 
@@ -43,22 +43,22 @@ public class CertificateBuilderTests
 
         //Test several different, equivalent ways of setting the Subject
 
-        using var cert1 = new CertificateBuilder().SetSubject(b => b.SetCommonName(testName)).Build();
+        using var cert1 = new CertificateBuilder().SetSubject(b => b.SetCommonName(testName)).Create();
         Assert.Equal(expected, cert1.Subject);
 
-        using var cert2 = new CertificateBuilder().SetSubject(new X500NameBuilder().SetCommonName(testName)).Build();
+        using var cert2 = new CertificateBuilder().SetSubject(new X500NameBuilder().SetCommonName(testName)).Create();
         Assert.Equal(expected, cert2.Subject);
 
-        using var cert3 = new CertificateBuilder().SetSubject(new X500DistinguishedName(expected)).Build();
+        using var cert3 = new CertificateBuilder().SetSubject(new X500DistinguishedName(expected)).Create();
         Assert.Equal(expected, cert3.Subject);
 
-        using var cert4 = new CertificateBuilder().SetSubject(new X509Name(expected)).Build();
+        using var cert4 = new CertificateBuilder().SetSubject(new X509Name(expected)).Create();
         Assert.Equal(expected, cert4.Subject);
 
-        using var cert5 = new CertificateBuilder().SetSubject(expected).Build();
+        using var cert5 = new CertificateBuilder().SetSubject(expected).Create();
         Assert.Equal(expected, cert5.Subject);
 
-        using var cert6 = new CertificateBuilder {Subject = new X500NameBuilder(expected)}.Build();
+        using var cert6 = new CertificateBuilder {Subject = new X500NameBuilder(expected)}.Create();
         Assert.Equal(expected, cert6.Subject);
     }
 
@@ -67,10 +67,10 @@ public class CertificateBuilderTests
     public void Build_Certificate_WithRSAKeys()
     {
         using var keys = RSA.Create();
-        using var cert1 = new CertificateBuilder().SetKeyPair(keys).Build();
+        using var cert1 = new CertificateBuilder().SetKeyPair(keys).Create();
         Assert.Equal(PkcsObjectIdentifiers.RsaEncryption.Id, cert1.GetKeyAlgorithm());
 
-        using var cert2 = new CertificateBuilder().SetKeyAlgorithm(KeyAlgorithm.RSA).Build();
+        using var cert2 = new CertificateBuilder().SetKeyAlgorithm(KeyAlgorithm.RSA).Create();
         Assert.Equal(PkcsObjectIdentifiers.RsaEncryption.Id, cert2.GetKeyAlgorithm());
     }
 
@@ -79,10 +79,10 @@ public class CertificateBuilderTests
     public void Build_Certificate_WithECDsaKeys()
     {
         using var keys = ECDsa.Create();
-        using var cert1 = new CertificateBuilder().SetKeyPair(keys).Build();
+        using var cert1 = new CertificateBuilder().SetKeyPair(keys).Create();
         Assert.Equal(X9ObjectIdentifiers.IdECPublicKey.Id, cert1.GetKeyAlgorithm());
 
-        using var cert2 = new CertificateBuilder().SetKeyAlgorithm(KeyAlgorithm.ECDsa).Build();
+        using var cert2 = new CertificateBuilder().SetKeyAlgorithm(KeyAlgorithm.ECDsa).Create();
         Assert.Equal(X9ObjectIdentifiers.IdECPublicKey.Id, cert2.GetKeyAlgorithm());
     }
 
@@ -91,10 +91,10 @@ public class CertificateBuilderTests
     public void Build_Certificate_WithDSAKeys()
     {
         using var keys = DSA.Create(1024);
-        using var cert1 = new CertificateBuilder().SetKeyPair(keys).Build();
+        using var cert1 = new CertificateBuilder().SetKeyPair(keys).Create();
         Assert.Equal(X9ObjectIdentifiers.IdDsa.Id, cert1.GetKeyAlgorithm());
 
-        using var cert2 = new CertificateBuilder().SetKeyAlgorithm(KeyAlgorithm.DSA).Build();
+        using var cert2 = new CertificateBuilder().SetKeyAlgorithm(KeyAlgorithm.DSA).Create();
         Assert.Equal(X9ObjectIdentifiers.IdDsa.Id, cert2.GetKeyAlgorithm());
     }
 
@@ -109,12 +109,12 @@ public class CertificateBuilderTests
             .SetSubject(x => x.SetCommonName("Root CA Test"))
             .SetNotAfter(now.AddHours(1))
             .SetKeyAlgorithm(KeyAlgorithm.ECDsa)
-            .Build();
+            .Create();
 
         using var cert = new CertificateBuilder()
             .SetIssuer(rootCA)
             .SetKeyAlgorithm(KeyAlgorithm.RSA)
-            .Build();
+            .Create();
 
         Assert.True(cert.IsIssuedBy(rootCA, true));
     }
@@ -130,12 +130,12 @@ public class CertificateBuilderTests
             .SetSubject(x => x.SetCommonName("Root CA Test"))
             .SetNotAfter(now.AddHours(1))
             .SetKeyAlgorithm(KeyAlgorithm.RSA)
-            .Build();
+            .Create();
 
         using var cert = new CertificateBuilder()
             .SetIssuer(rootCA)
             .SetKeyAlgorithm(KeyAlgorithm.ECDsa)
-            .Build();
+            .Create();
 
         Assert.True(cert.IsIssuedBy(rootCA, true));
     }
@@ -147,7 +147,7 @@ public class CertificateBuilderTests
         Skip.IfNot(Tools.IsWindows);
 
         const string friendlyName = "A FriendlyName can be set on Windows";
-        using var cert = new CertificateBuilder().SetFriendlyName(friendlyName).Build();
+        using var cert = new CertificateBuilder().SetFriendlyName(friendlyName).Create();
         Assert.Equal(friendlyName, cert.FriendlyName);
     }
 
@@ -156,13 +156,13 @@ public class CertificateBuilderTests
     public void Build_InvalidKeyLength_ThrowsException()
     {
         Assert.ThrowsAny<Exception>(() => {
-            using var cert = new CertificateBuilder().SetKeyLength(10).Build();
+            using var cert = new CertificateBuilder().SetKeyLength(10).Create();
         });
         Assert.Throws<ArgumentException>(() => {
-            using var cert = new CertificateBuilder().SetKeyLength(0).Build();
+            using var cert = new CertificateBuilder().SetKeyLength(0).Create();
         });
         Assert.Throws<ArgumentException>(() => {
-            using var cert = new CertificateBuilder().SetKeyLength(-1024).Build();
+            using var cert = new CertificateBuilder().SetKeyLength(-1024).Create();
         });
     }
 
@@ -170,7 +170,7 @@ public class CertificateBuilderTests
     [Fact]
     public void Build_MinimalCertificate_IsValid()
     {
-        using var cert = new CertificateBuilder().Build();
+        using var cert = new CertificateBuilder().Create();
 
         Assert.NotNull(cert);
         Assert.True(cert.IsValidNow());
@@ -183,7 +183,7 @@ public class CertificateBuilderTests
         using var rootCa = new CertificateBuilder()
             .SetUsage(CertificateUsage.CA)
             .SetSubject(x => x.SetCommonName("Root CA Test"))
-            .Build();
+            .Create();
 
         Assert.Contains(rootCa.Extensions.OfType<X509BasicConstraintsExtension>(), x => x.CertificateAuthority);
         Assert.True(rootCa.IsSelfSigned());
@@ -199,14 +199,14 @@ public class CertificateBuilderTests
             .SetUsage(CertificateUsage.CA)
             .SetSubject(x => x.SetCommonName("Root CA Test"))
             .SetNotAfter(now.AddHours(1))
-            .Build();
+            .Create();
 
         using var subCa = new CertificateBuilder()
             .SetUsage(CertificateUsage.CA)
             .SetSubject(x => x.SetCommonName("Subordinate CA Test"))
             .SetNotAfter(now.AddMinutes(1))
             .SetIssuer(rootCa)
-            .Build();
+            .Create();
 
         Assert.Contains(rootCa.Extensions.OfType<X509BasicConstraintsExtension>(), x => x.CertificateAuthority);
         Assert.True(subCa.IsIssuedBy(rootCa, true));
@@ -220,14 +220,14 @@ public class CertificateBuilderTests
             .SetUsage(CertificateUsage.CA)
             .SetSubject(x => x.SetCommonName("Root CA Test"))
             .SetNotAfter(DateTimeOffset.UtcNow.AddDays(7))
-            .Build();
+            .Create();
 
         using var subCa = new CertificateBuilder()
             .SetUsage(CertificateUsage.CA)
             .SetSubject(x => x.SetCommonName("Intermediate CA Test"))
             .SetNotAfter(DateTimeOffset.UtcNow.AddDays(6))
             .SetIssuer(rootCa)
-            .Build();
+            .Create();
 
         using var cert = new CertificateBuilder()
             .SetUsage(CertificateUsage.Server)
@@ -236,7 +236,7 @@ public class CertificateBuilderTests
             .SetSubject(x => x.SetCommonName("*.fake.domain"))
             .SetNotAfter(DateTimeOffset.UtcNow.AddDays(1))
             .SetIssuer(subCa)
-            .Build();
+            .Create();
 
         Assert.True(cert.IsValidNow());
         Assert.True(rootCa.IsIssuedBy(rootCa, true));
@@ -259,7 +259,7 @@ public class CertificateBuilderTests
 
         var csr = new CertificateBuilder()
             .SetKeyPair(keys)
-            .BuildCertificateSigningRequest();
+            .CreateCertificateSigningRequest();
 
         Assert.NotEmpty(csr.GetRawData());
         

--- a/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
+++ b/tests/FluentCertificates.Builder.Tests/CertificateBuilderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -12,6 +13,7 @@ using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Asn1.X9;
 
 using Xunit;
+using Xunit.Abstractions;
 
 using X509Extension = System.Security.Cryptography.X509Certificates.X509Extension;
 
@@ -20,6 +22,11 @@ namespace FluentCertificates;
 
 public class CertificateBuilderTests
 {
+    public CertificateBuilderTests(ITestOutputHelper outputHelper) {
+        OutputHelper = outputHelper;
+    }
+
+
     [Fact]
     public void Build_NewCertificate_HasPrivateKey()
     {
@@ -243,6 +250,22 @@ public class CertificateBuilderTests
         Assert.Contains(san, x => x.Name.ToString() == "fake.domain");
         Assert.Contains(san, x => x.Name.ToString() == "another.domain");
     }
+
+
+    [Fact]
+    public void Build_CertificateSigningRequest_WithExternalKeys()
+    {
+        using var keys = RSA.Create();
+
+        var csr = new CertificateBuilder()
+            .SetKeyPair(keys)
+            .BuildCertificateSigningRequest();
+
+        Assert.NotEmpty(csr);
+    }
+
+
+    private readonly ITestOutputHelper OutputHelper;
 
 
     private static IEnumerable<GeneralName> EnumerateNamesFromSAN(X509Extension extension)

--- a/tests/FluentCertificates.Builder.Tests/Fixtures/CertificateTestingFixture.cs
+++ b/tests/FluentCertificates.Builder.Tests/Fixtures/CertificateTestingFixture.cs
@@ -40,7 +40,7 @@ public sealed class CertificateTestingFixture : IDisposable
             .SetSubject(new X500NameBuilder().SetCommonName($"{CertNamePrefix} {name}"))
             .SetNotAfter(DateTimeOffset.UtcNow.AddYears(years))
             .SetIssuer(issuer)
-            .Build();
+            .Create();
 
 
     private readonly Lazy<X509Certificate2> _rootCa;

--- a/tests/FluentCertificates.Builder.Tests/X500NameBuilderTests.cs
+++ b/tests/FluentCertificates.Builder.Tests/X500NameBuilderTests.cs
@@ -117,7 +117,7 @@ public class X500NameBuilderTests
             .Clear();
 
         Assert.Empty(builder.Attributes);
-        Assert.Empty(builder.Build().Name);
+        Assert.Empty(builder.Create().Name);
     }
 
 
@@ -163,7 +163,7 @@ public class X500NameBuilderTests
         Assert.Equal("DC=app,DC=fake",
             new X500NameBuilder()
                 .SetDomainComponents("app", "fake")
-                .Build()
+                .Create()
                 .Name
         );
 
@@ -172,7 +172,7 @@ public class X500NameBuilderTests
                 .AddOrganizationalUnit("services")
                 .AddDomainComponents("old", "domain", "to", "remove")
                 .SetDomainComponents("app", "fake")
-                .Build()
+                .Create()
                 .Name
         );
     }

--- a/tests/FluentCertificates.Extensions.Tests/X509Certificate2ExtensionsTests.cs
+++ b/tests/FluentCertificates.Extensions.Tests/X509Certificate2ExtensionsTests.cs
@@ -14,10 +14,10 @@ public class X509Certificate2ExtensionsTests
     public void Certificate_IssuedBy_VerifiesIssuerSignature(KeyAlgorithm alg)
     {
         var builder = new CertificateBuilder().SetSubject("CN=Test Issuer");
-        using var faker = builder.SetKeyAlgorithm(alg).Build();
-        using var issuer = builder.SetKeyAlgorithm(alg).Build();
+        using var faker = builder.SetKeyAlgorithm(alg).Create();
+        using var issuer = builder.SetKeyAlgorithm(alg).Create();
 
-        using var cert = new CertificateBuilder().SetIssuer(issuer).Build();
+        using var cert = new CertificateBuilder().SetIssuer(issuer).Create();
 
         //The fake issuer has the same subject-name as the real issuer
         Assert.True(cert.IsIssuedBy(faker, verifySignature: false));
@@ -34,7 +34,7 @@ public class X509Certificate2ExtensionsTests
     [MemberData(nameof(KeyAlgorithmsAndExportKeysTestData))]
     public void ExportAsPem_ToWriter_RawDataIsEqual(KeyAlgorithm alg, ExportKeys include, string password)
     {
-        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
         using var stream = new MemoryStream();
         using (var writer = new StreamWriter(stream, Encoding.ASCII, leaveOpen: true)) {
@@ -69,7 +69,7 @@ public class X509Certificate2ExtensionsTests
     {
         var tmpFile = Path.ChangeExtension(Path.GetTempFileName(), "pem");
         try {
-            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
             expected.ExportAsPem(tmpFile, password, include);
             var parser = new X509CertificateParser();
@@ -101,7 +101,7 @@ public class X509Certificate2ExtensionsTests
     [MemberData(nameof(KeyAlgorithmsTestData))]
     public void ExportAsCert_ToWriter_RawDataIsEqual(KeyAlgorithm alg)
     {
-        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream)) {
@@ -121,7 +121,7 @@ public class X509Certificate2ExtensionsTests
     {
         var tmpFile = Path.ChangeExtension(Path.GetTempFileName(), "crt");
         try {
-            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
             expected.ExportAsCert(tmpFile);
             using var actual = new X509Certificate2(tmpFile);
@@ -139,7 +139,7 @@ public class X509Certificate2ExtensionsTests
     [MemberData(nameof(KeyAlgorithmsTestData))]
     public void ExportAsPkcs7_ToWriter_RawDataIsEqual(KeyAlgorithm alg)
     {
-        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream)) {
@@ -161,7 +161,7 @@ public class X509Certificate2ExtensionsTests
     {
         var tmpFile = Path.ChangeExtension(Path.GetTempFileName(), "p7b");
         try {
-            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
             expected.ExportAsPkcs7(tmpFile);
             var cms = new SignedCms();
@@ -181,7 +181,7 @@ public class X509Certificate2ExtensionsTests
     [MemberData(nameof(KeyAlgorithmsAndExportKeysTestData))]
     public void ExportAsPkcs12_ToWriter_RawDataIsEqual(KeyAlgorithm alg, ExportKeys include, string password)
     {
-        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+        using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
         using var stream = new MemoryStream();
         using (var writer = new BinaryWriter(stream)) {
@@ -205,7 +205,7 @@ public class X509Certificate2ExtensionsTests
     {
         var tmpFile = Path.ChangeExtension(Path.GetTempFileName(), "pfx");
         try {
-            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Build();
+            using var expected = new CertificateBuilder().SetKeyAlgorithm(alg).Create();
 
             expected.ExportAsPkcs12(tmpFile, password, include);
             using var actual = new X509Certificate2(tmpFile, password);

--- a/tests/FluentCertificates.Extensions.Tests/X509ChainExtensionsTests.cs
+++ b/tests/FluentCertificates.Extensions.Tests/X509ChainExtensionsTests.cs
@@ -9,20 +9,20 @@ public class X509ChainExtensionsTests
             .SetUsage(CertificateUsage.CA)
             .SetNotAfter(DateTimeOffset.UtcNow.AddDays(3))
             .SetSubject("CN=RootCA")
-            .Build();
+            .Create();
 
         using var subCa = new CertificateBuilder()
             .SetUsage(CertificateUsage.CA)
             .SetNotAfter(DateTimeOffset.UtcNow.AddDays(2))
             .SetIssuer(rootCa)
             .SetSubject("CN=SubCA")
-            .Build();
+            .Create();
 
         using var cert = new CertificateBuilder()
             .SetNotAfter(DateTimeOffset.UtcNow.AddDays(1))
             .SetIssuer(subCa)
             .SetSubject("CN=Leaf")
-            .Build();
+            .Create();
 
         using var chain = cert.BuildChain(new[] { subCa, rootCa }, true);
 


### PR DESCRIPTION
Summary of changes:
- Created a CertificateSigningRequest class: this differs from .NET's built-in CertificateRequest by wrapping it and providing easy access to a signed request and some of its internal data (signature, algorithm, etc.).
- CertificateBuilder's `CreateCertificateSigningRequest()` method now initializes, and returns a CertificateSigningRequest.
- Added a few more polyfills for older .NET versions.

Breaking changes:
- This PR renames all builders' `Build()` methods to `Create()`.
- X509Certificate2 extension method `GetTbsData()` is renamed to `GetToBeSignedData()`
- X509Certificate2 extension methods `GetToBeSignedData()` and `GetSignatureData()` now return ReadOnlyMemory<byte> instead of byte[].

Resolved #8.